### PR TITLE
Tt pretrained

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidybert
 Title: Tidy BERT-like Models
-Version: 0.0.0.9500
+Version: 0.0.0.9600
 Authors@R: c(
     person(given = "Jonathan",
            family = "Bratt",
@@ -34,7 +34,7 @@ Imports:
     stats,
     tibble,
     torch,
-    torchtransformers (>= 0.0.0.9300)
+    torchtransformers (>= 0.0.0.9400)
 Remotes:
     macmillancontentscience/torchtransformers
 Suggests: 

--- a/R/bert_classification-fit.R
+++ b/R/bert_classification-fit.R
@@ -17,6 +17,12 @@
 #' `bert_classification()` fits a classifier neural network in the style of
 #' [BERT from Google Research](https://github.com/google-research/bert).
 #'
+#' The generated model is a pretrained BERT model with a final dense linear
+#' layer to map the output to the outcome levels, constructed using
+#' [model_bert_linear()]. That pretrained model is fine-tuned on the provided
+#' training data. Input data (during both fitting and prediction) is
+#' automatically tokenized to match the tokenization expected by the BERT model.
+#'
 #' @param x Depending on the context:
 #'
 #'   * A __data frame__ of character predictors.
@@ -31,12 +37,11 @@
 #'   * A __matrix__ with 1 factor column.
 #'   * A factor __vector__.
 #'
-#' @param valid_x Depending on the context:
-#'   * A number between 0 and 1, representing the fraction of data to use for
-#'     model validation.
-#'   * Predictors in the same format as `x`. These predictors will be used for
-#'     model validation.
-#'   * `NULL`, in which case no data will be used for model validation.
+#' @param valid_x Depending on the context: * A number between 0 and 1,
+#'   representing the fraction of data to use for model validation. * Predictors
+#'   in the same format as `x`. These predictors will be used for model
+#'   validation. * `NULL`, in which case no data will be used for model
+#'   validation.
 #'
 #' @param valid_y When `valid_x` is a set of predictors, `valid_y` should be
 #'   outcomes in the same format as `y`.
@@ -44,7 +49,7 @@
 #' @param data When a __formula__ is used, `data` is specified as:
 #'
 #'   * A __data frame__ containing both the predictors and the outcome. The
-#'     predictors should be character vectors. The outcome should be a factor.
+#'   predictors should be character vectors. The outcome should be a factor.
 #'
 #' @param formula A formula specifying the outcome term on the left-hand side,
 #'   and the predictor terms on the right-hand side.
@@ -330,7 +335,7 @@ bert_classification.formula <- function(formula,
 #' @param luz_opt_hparams List; parameters to pass on to
 #'   \code{\link[luz]{set_opt_hparams}} to initialize the optimizer.
 #' @inheritParams model_bert_linear
-#' @inheritParams torchtransformers::dataset_bert
+#' @inheritParams torchtransformers::dataset_bert_pretrained
 #' @inheritParams luz::setup
 #' @inheritParams luz::fit.luz_module_generator
 #' @inheritParams torch::dataloader

--- a/R/bert_classification-fit.R
+++ b/R/bert_classification-fit.R
@@ -37,11 +37,13 @@
 #'   * A __matrix__ with 1 factor column.
 #'   * A factor __vector__.
 #'
-#' @param valid_x Depending on the context: * A number between 0 and 1,
-#'   representing the fraction of data to use for model validation. * Predictors
-#'   in the same format as `x`. These predictors will be used for model
-#'   validation. * `NULL`, in which case no data will be used for model
-#'   validation.
+#' @param valid_x Depending on the context:
+#'
+#'   * A number between 0 and 1, representing the fraction of data to use for
+#'     model validation.
+#'   * Predictors in the same format as `x`. These predictors will be used for
+#'     model validation.
+#'   * `NULL`, in which case no data will be used for model validation.
 #'
 #' @param valid_y When `valid_x` is a set of predictors, `valid_y` should be
 #'   outcomes in the same format as `y`.

--- a/R/bert_classification-predict.R
+++ b/R/bert_classification-predict.R
@@ -53,7 +53,7 @@ predict.bert_classification <- function(object,
 #' @keywords internal
 .predict_bert_classification_bridge <- function(type, object, predictors) {
   # Prepare the input.
-  predictors_ds <- torchtransformers::dataset_bert(
+  predictors_ds <- torchtransformers::dataset_bert_pretrained(
     x = predictors,
     y = NULL,
     n_tokens = object$n_tokens
@@ -101,7 +101,17 @@ predict.bert_classification <- function(object,
   # Get the prediction output and apply softmax.
   return(
     torch::nnf_softmax(
-      input = predict(object$luz_model, predictors),
+      input = predict(
+        object$luz_model,
+        predictors,
+        # TODO: Allow additional luz:::predict.luz_module_fitted arguments.
+        callbacks = list(
+          torchtransformers::luz_callback_bert_tokenize(
+            submodel_name = "bert",
+            verbose = interactive()
+          )
+        )
+      ),
       dim = 2
     )
   )

--- a/R/bert_classification-predict.R
+++ b/R/bert_classification-predict.R
@@ -12,24 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#' Predict from a `bert_classification`
+#' Predict from a `bert_classification` model.
 #'
 #' @param object A `bert_classification` object.
 #'
-#' @param new_data A data frame or matrix of new predictors.
+#' @param new_data A data frame or matrix of new character predictors. This data
+#'   is automatically tokenized to match the tokenization expected by the BERT
+#'   model.
 #'
-#' @param type A single character. The type of predictions to generate.
-#' Valid options are:
+#' @param type A single character. The type of predictions to generate. Valid
+#'   options are:
 #'
-#' - `"class"` for "hard" class predictions.
-#' - `"prob"` for class probabilities.
+#'   - `"class"` for "hard" class predictions.
+#'   - `"prob"` for class probabilities.
 #'
 #' @param ... Not used, but required for extensibility.
 #'
 #' @return
 #'
-#' A tibble of predictions. The number of rows in the tibble is guaranteed
-#' to be the same as the number of rows in `new_data`.
+#' A tibble of predictions. The number of rows in the tibble is guaranteed to be
+#' the same as the number of rows in `new_data`.
 #'
 #' @export
 predict.bert_classification <- function(object,

--- a/R/bert_linear.R
+++ b/R/bert_linear.R
@@ -20,7 +20,7 @@
 #' to attach a classification head to BERT using other techniques, but here we
 #' use this simple technique.
 #'
-#' @inheritParams torchtransformers::make_and_load_bert
+#' @inheritParams torchtransformers::model_bert_pretrained
 #' @param output_dim Integer; the target number of output dimensions.
 #'
 #' @return A torch neural net model with pretrained BERT weights and a final
@@ -28,11 +28,11 @@
 #' @export
 model_bert_linear <- torch::nn_module(
   "bert_linear",
-  initialize = function(model_name = "bert_tiny_uncased", output_dim = 1L) {
+  initialize = function(bert_type = "bert_tiny_uncased", output_dim = 1L) {
     embedding_size <- torchtransformers::config_bert(
-      model_name, "embedding_size"
+      bert_type, "embedding_size"
     )
-    self$bert <- torchtransformers::make_and_load_bert(model_name)
+    self$bert <- torchtransformers::model_bert_pretrained(bert_type)
     # After pooled bert output, do a final dense layer.
     self$linear <- torch::nn_linear(
       in_features = embedding_size,
@@ -46,7 +46,7 @@ model_bert_linear <- torch::nn_module(
     )
   },
   forward = function(x) {
-    output <- self$bert(x$token_ids, x$token_type_ids)
+    output <- self$bert(x)
 
     # Take the output embeddings from the last layer.
     output <- output$output_embeddings

--- a/man/bert_classification.Rd
+++ b/man/bert_classification.Rd
@@ -78,11 +78,14 @@ specified as:
 \item A factor \strong{vector}.
 }}
 
-\item{valid_x}{Depending on the context: * A number between 0 and 1,
-representing the fraction of data to use for model validation. * Predictors
-in the same format as \code{x}. These predictors will be used for model
-validation. * \code{NULL}, in which case no data will be used for model
-validation.}
+\item{valid_x}{Depending on the context:
+\itemize{
+\item A number between 0 and 1, representing the fraction of data to use for
+model validation.
+\item Predictors in the same format as \code{x}. These predictors will be used for
+model validation.
+\item \code{NULL}, in which case no data will be used for model validation.
+}}
 
 \item{valid_y}{When \code{valid_x} is a set of predictors, \code{valid_y} should be
 outcomes in the same format as \code{y}.}

--- a/man/bert_classification.Rd
+++ b/man/bert_classification.Rd
@@ -17,8 +17,8 @@ bert_classification(x, ...)
   y,
   valid_x = 0.1,
   valid_y = NULL,
-  model_name = "bert_tiny_uncased",
-  n_tokens = torchtransformers::config_bert(model_name, "max_tokens"),
+  bert_type = "bert_tiny_uncased",
+  n_tokens = torchtransformers::config_bert(bert_type, "max_tokens"),
   loss = torch::nn_cross_entropy_loss(),
   optimizer = torch::optim_adam,
   metrics = list(luz::luz_metric_accuracy()),
@@ -33,8 +33,8 @@ bert_classification(x, ...)
   y,
   valid_x = 0.1,
   valid_y = NULL,
-  model_name = "bert_tiny_uncased",
-  n_tokens = torchtransformers::config_bert(model_name, "max_tokens"),
+  bert_type = "bert_tiny_uncased",
+  n_tokens = torchtransformers::config_bert(bert_type, "max_tokens"),
   loss = torch::nn_cross_entropy_loss(),
   optimizer = torch::optim_adam,
   metrics = list(luz::luz_metric_accuracy()),
@@ -48,8 +48,8 @@ bert_classification(x, ...)
   formula,
   data,
   valid_data = 0.1,
-  model_name = "bert_tiny_uncased",
-  n_tokens = torchtransformers::config_bert(model_name, "max_tokens"),
+  bert_type = "bert_tiny_uncased",
+  n_tokens = torchtransformers::config_bert(bert_type, "max_tokens"),
   loss = torch::nn_cross_entropy_loss(),
   optimizer = torch::optim_adam,
   metrics = list(luz::luz_metric_accuracy()),
@@ -90,8 +90,8 @@ model validation.
 \item{valid_y}{When \code{valid_x} is a set of predictors, \code{valid_y} should be
 outcomes in the same format as \code{y}.}
 
-\item{model_name}{Character; which flavor of BERT to use. See
-\code{\link[torchtransformers]{available_berts}} for known models.}
+\item{bert_type}{Character; which flavor of BERT to use. See
+\code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
 \item{n_tokens}{Integer scalar; the number of tokens expected for each
 example.}

--- a/man/bert_classification.Rd
+++ b/man/bert_classification.Rd
@@ -78,14 +78,11 @@ specified as:
 \item A factor \strong{vector}.
 }}
 
-\item{valid_x}{Depending on the context:
-\itemize{
-\item A number between 0 and 1, representing the fraction of data to use for
-model validation.
-\item Predictors in the same format as \code{x}. These predictors will be used for
-model validation.
-\item \code{NULL}, in which case no data will be used for model validation.
-}}
+\item{valid_x}{Depending on the context: * A number between 0 and 1,
+representing the fraction of data to use for model validation. * Predictors
+in the same format as \code{x}. These predictors will be used for model
+validation. * \code{NULL}, in which case no data will be used for model
+validation.}
 
 \item{valid_y}{When \code{valid_x} is a set of predictors, \code{valid_y} should be
 outcomes in the same format as \code{y}.}
@@ -93,8 +90,8 @@ outcomes in the same format as \code{y}.}
 \item{bert_type}{Character; which flavor of BERT to use. See
 \code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
-\item{n_tokens}{Integer scalar; the number of tokens expected for each
-example.}
+\item{n_tokens}{An integer scalar indicating the number of tokens in the
+output.}
 
 \item{loss}{(\code{function}, optional) An optional function with the signature
 \verb{function(input, target)}. It's only requires if your \code{nn_module} doesn't
@@ -144,4 +141,11 @@ A \code{bert_classification} object.
 \description{
 \code{bert_classification()} fits a classifier neural network in the style of
 \href{https://github.com/google-research/bert}{BERT from Google Research}.
+}
+\details{
+The generated model is a pretrained BERT model with a final dense linear
+layer to map the output to the outcome levels, constructed using
+\code{\link[=model_bert_linear]{model_bert_linear()}}. That pretrained model is fine-tuned on the provided
+training data. Input data (during both fitting and prediction) is
+automatically tokenized to match the tokenization expected by the BERT model.
 }

--- a/man/dot-bert_classification_bridge.Rd
+++ b/man/dot-bert_classification_bridge.Rd
@@ -27,8 +27,8 @@ dataset.}
 \item{bert_type}{Character; which flavor of BERT to use. See
 \code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
-\item{n_tokens}{Integer scalar; the number of tokens expected for each
-example.}
+\item{n_tokens}{An integer scalar indicating the number of tokens in the
+output.}
 
 \item{loss}{(\code{function}, optional) An optional function with the signature
 \verb{function(input, target)}. It's only requires if your \code{nn_module} doesn't

--- a/man/dot-bert_classification_bridge.Rd
+++ b/man/dot-bert_classification_bridge.Rd
@@ -7,8 +7,8 @@
 .bert_classification_bridge(
   processed,
   valid_data = 0.1,
-  model_name = "bert_tiny_uncased",
-  n_tokens = torchtransformers::config_bert(model_name, "max_tokens"),
+  bert_type = "bert_tiny_uncased",
+  n_tokens = torchtransformers::config_bert(bert_type, "max_tokens"),
   loss = torch::nn_cross_entropy_loss(),
   optimizer = torch::optim_adam,
   metrics = list(luz::luz_metric_accuracy()),
@@ -24,8 +24,8 @@
 \item{valid_data}{Either a number between 0 and 1, or a blueprint-processed
 dataset.}
 
-\item{model_name}{Character; which flavor of BERT to use. See
-\code{\link[torchtransformers]{available_berts}} for known models.}
+\item{bert_type}{Character; which flavor of BERT to use. See
+\code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
 \item{n_tokens}{Integer scalar; the number of tokens expected for each
 example.}

--- a/man/dot-bert_classification_impl.Rd
+++ b/man/dot-bert_classification_impl.Rd
@@ -30,8 +30,8 @@ dataset.}
 \item{bert_type}{Character; which flavor of BERT to use. See
 \code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
-\item{n_tokens}{Integer scalar; the number of tokens expected for each
-example.}
+\item{n_tokens}{An integer scalar indicating the number of tokens in the
+output.}
 
 \item{loss}{(\code{function}, optional) An optional function with the signature
 \verb{function(input, target)}. It's only requires if your \code{nn_module} doesn't

--- a/man/dot-bert_classification_impl.Rd
+++ b/man/dot-bert_classification_impl.Rd
@@ -8,8 +8,8 @@
   predictors,
   outcome,
   valid_data = 0.1,
-  model_name = "bert_tiny_uncased",
-  n_tokens = torchtransformers::config_bert(model_name, "max_tokens"),
+  bert_type = "bert_tiny_uncased",
+  n_tokens = torchtransformers::config_bert(bert_type, "max_tokens"),
   loss = torch::nn_cross_entropy_loss(),
   optimizer = torch::optim_adam,
   metrics = list(luz::luz_metric_accuracy()),
@@ -27,8 +27,8 @@
 \item{valid_data}{Either a number between 0 and 1, or a blueprint-processed
 dataset.}
 
-\item{model_name}{Character; which flavor of BERT to use. See
-\code{\link[torchtransformers]{available_berts}} for known models.}
+\item{bert_type}{Character; which flavor of BERT to use. See
+\code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
 \item{n_tokens}{Integer scalar; the number of tokens expected for each
 example.}

--- a/man/dot-get_bert_classification_predict_function.Rd
+++ b/man/dot-get_bert_classification_predict_function.Rd
@@ -7,8 +7,8 @@
 .get_bert_classification_predict_function(type)
 }
 \arguments{
-\item{type}{A single character. The type of predictions to generate.
-Valid options are:
+\item{type}{A single character. The type of predictions to generate. Valid
+options are:
 \itemize{
 \item \code{"class"} for "hard" class predictions.
 \item \code{"prob"} for class probabilities.

--- a/man/dot-mold_valid_xy.Rd
+++ b/man/dot-mold_valid_xy.Rd
@@ -7,11 +7,14 @@
 .mold_valid_xy(valid_x, valid_y, blueprint)
 }
 \arguments{
-\item{valid_x}{Depending on the context: * A number between 0 and 1,
-representing the fraction of data to use for model validation. * Predictors
-in the same format as \code{x}. These predictors will be used for model
-validation. * \code{NULL}, in which case no data will be used for model
-validation.}
+\item{valid_x}{Depending on the context:
+\itemize{
+\item A number between 0 and 1, representing the fraction of data to use for
+model validation.
+\item Predictors in the same format as \code{x}. These predictors will be used for
+model validation.
+\item \code{NULL}, in which case no data will be used for model validation.
+}}
 
 \item{valid_y}{When \code{valid_x} is a set of predictors, \code{valid_y} should be
 outcomes in the same format as \code{y}.}

--- a/man/dot-mold_valid_xy.Rd
+++ b/man/dot-mold_valid_xy.Rd
@@ -7,14 +7,11 @@
 .mold_valid_xy(valid_x, valid_y, blueprint)
 }
 \arguments{
-\item{valid_x}{Depending on the context:
-\itemize{
-\item A number between 0 and 1, representing the fraction of data to use for
-model validation.
-\item Predictors in the same format as \code{x}. These predictors will be used for
-model validation.
-\item \code{NULL}, in which case no data will be used for model validation.
-}}
+\item{valid_x}{Depending on the context: * A number between 0 and 1,
+representing the fraction of data to use for model validation. * Predictors
+in the same format as \code{x}. These predictors will be used for model
+validation. * \code{NULL}, in which case no data will be used for model
+validation.}
 
 \item{valid_y}{When \code{valid_x} is a set of predictors, \code{valid_y} should be
 outcomes in the same format as \code{y}.}

--- a/man/dot-predict_bert_classification_bridge.Rd
+++ b/man/dot-predict_bert_classification_bridge.Rd
@@ -7,8 +7,8 @@
 .predict_bert_classification_bridge(type, object, predictors)
 }
 \arguments{
-\item{type}{A single character. The type of predictions to generate.
-Valid options are:
+\item{type}{A single character. The type of predictions to generate. Valid
+options are:
 \itemize{
 \item \code{"class"} for "hard" class predictions.
 \item \code{"prob"} for class probabilities.

--- a/man/model_bert_linear.Rd
+++ b/man/model_bert_linear.Rd
@@ -4,11 +4,11 @@
 \alias{model_bert_linear}
 \title{Pretrained BERT Model with Linear Output}
 \usage{
-model_bert_linear(model_name = "bert_tiny_uncased", output_dim = 1L)
+model_bert_linear(bert_type = "bert_tiny_uncased", output_dim = 1L)
 }
 \arguments{
-\item{model_name}{Character; which flavor of BERT to use. See
-\code{\link[torchtransformers]{available_berts}} for known models.}
+\item{bert_type}{Character; which flavor of BERT to use. See
+\code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
 
 \item{output_dim}{Integer; the target number of output dimensions.}
 }

--- a/man/predict.bert_classification.Rd
+++ b/man/predict.bert_classification.Rd
@@ -2,17 +2,19 @@
 % Please edit documentation in R/bert_classification-predict.R
 \name{predict.bert_classification}
 \alias{predict.bert_classification}
-\title{Predict from a \code{bert_classification}}
+\title{Predict from a \code{bert_classification} model.}
 \usage{
 \method{predict}{bert_classification}(object, new_data, type = c("class", "prob"), ...)
 }
 \arguments{
 \item{object}{A \code{bert_classification} object.}
 
-\item{new_data}{A data frame or matrix of new predictors.}
+\item{new_data}{A data frame or matrix of new character predictors. This data
+is automatically tokenized to match the tokenization expected by the BERT
+model.}
 
-\item{type}{A single character. The type of predictions to generate.
-Valid options are:
+\item{type}{A single character. The type of predictions to generate. Valid
+options are:
 \itemize{
 \item \code{"class"} for "hard" class predictions.
 \item \code{"prob"} for class probabilities.
@@ -21,9 +23,9 @@ Valid options are:
 \item{...}{Not used, but required for extensibility.}
 }
 \value{
-A tibble of predictions. The number of rows in the tibble is guaranteed
-to be the same as the number of rows in \code{new_data}.
+A tibble of predictions. The number of rows in the tibble is guaranteed to be
+the same as the number of rows in \code{new_data}.
 }
 \description{
-Predict from a \code{bert_classification}
+Predict from a \code{bert_classification} model.
 }

--- a/tests/testthat/_snaps/bert_classification-fit.md
+++ b/tests/testthat/_snaps/bert_classification-fit.md
@@ -22,7 +22,7 @@
       An `nn_module` containing 4,369,667 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #258 parameters
       
       -- Parameters ------------------------------------------------------------------
@@ -61,7 +61,7 @@
       An `nn_module` containing 4,369,667 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #258 parameters
       
       -- Parameters ------------------------------------------------------------------
@@ -100,7 +100,7 @@
       An `nn_module` containing 4,369,667 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #258 parameters
       
       -- Parameters ------------------------------------------------------------------
@@ -139,7 +139,7 @@
       An `nn_module` containing 4,369,667 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #258 parameters
       
       -- Parameters ------------------------------------------------------------------
@@ -178,7 +178,7 @@
       An `nn_module` containing 4,369,667 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #258 parameters
       
       -- Parameters ------------------------------------------------------------------

--- a/tests/testthat/_snaps/bert_linear.md
+++ b/tests/testthat/_snaps/bert_linear.md
@@ -6,7 +6,7 @@
       An `nn_module` containing 4,369,538 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #129 parameters
       
       -- Parameters ------------------------------------------------------------------
@@ -58,7 +58,7 @@
       An `nn_module` containing 4,369,925 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #4,369,408 parameters
+      * bert: <BERT_pretrained> #4,369,408 parameters
       * linear: <nn_linear> #516 parameters
       
       -- Parameters ------------------------------------------------------------------
@@ -110,7 +110,7 @@
       An `nn_module` containing 28,502,532 parameters.
       
       -- Modules ---------------------------------------------------------------------
-      * bert: <BERT> #28,500,992 parameters
+      * bert: <BERT_pretrained> #28,500,992 parameters
       * linear: <nn_linear> #1,539 parameters
       
       -- Parameters ------------------------------------------------------------------

--- a/tests/testthat/test-bert_linear.R
+++ b/tests/testthat/test-bert_linear.R
@@ -14,7 +14,7 @@ test_that("model_bert_linear produced the expected model", {
 
   output_dim <- 3L
   test_result <- model_bert_linear(
-    model_name = "bert_small_uncased",
+    bert_type = "bert_small_uncased",
     output_dim = output_dim
   )
   expect_snapshot(test_result)

--- a/tests/testthat/test-tidy_output.R
+++ b/tests/testthat/test-tidy_output.R
@@ -1,5 +1,5 @@
 test_that("bert output tidiers work", {
-  bert_model <- torchtransformers::make_and_load_bert("bert_tiny_uncased")
+  bert_model <- torchtransformers::model_bert_pretrained("bert_tiny_uncased")
 
   test_input_1 <- c("Why didn't the chicken cross the road?",
                     "Why didn't the chicken cross the road?")
@@ -14,11 +14,14 @@ test_that("bert output tidiers work", {
                                                 test_input_2,
                                                 n_tokens = n_tokens)
   # format the input
-  token_input <- torch::torch_tensor(tokenized$token_ids)
-  tt_input <- torch::torch_tensor(tokenized$token_type_ids)
+  x <- list(
+    token_ids = torch::torch_tensor(tokenized$token_ids),
+    token_type_ids = torch::torch_tensor(tokenized$token_type_ids)
+  )
+
 
   bert_model$eval()
-  bert_output <- bert_model(token_input, tt_input)
+  bert_output <- bert_model(x)
   tidy_out <- tidy_bert_output(bert_output, tokenized)
 
   # check the column names and the first few values

--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -56,8 +56,7 @@ text_inputs
 
 We want to produce contextual embeddings for these sequences.
 First we tokenize the input text into the format required by the model. 
-We'll use the `tokenize_bert` function exported from the {torchtransformers} package (the api here will likely be
-changing soon).
+We'll use the `tokenize_bert` function exported from the {torchtransformers} package (the api here will likely be changing soon).
 
 ```{r}
 # Set the number of tokens to pad/truncate the result to.
@@ -65,7 +64,12 @@ n_tokens <- 20L
 tokenized <- torchtransformers::tokenize_bert(
   text_inputs$segment1,
   text_inputs$segment2,
-  n_tokens = n_tokens
+  n_tokens = n_tokens,
+  # The tokenizer and vocabulary must match the model. While these are the
+  # defaults, we're calling it out here explicitly until we update this API to
+  # make it more straightforward.
+  tokenizer = wordpiece::wordpiece_tokenize,
+  vocab = wordpiece.data::wordpiece_vocab()
 )
 ```
 

--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -72,14 +72,9 @@ tokenized <- torchtransformers::tokenize_bert(
 Load a pretrained BERT model and pass in the input:
 
 ```{r}
-# If we're downloading this model for the first time, it can take longer than
-# the default timeout.
-# TODO: Build this into torchtransformers and/or dlr.
-old_timeout <- options(timeout = 1000)
 bert_model <- torchtransformers::model_bert_pretrained(
   bert_type = "bert_base_uncased"
 )
-options(old_timeout)
 
 bert_model$eval() 
 bert_output <- bert_model(

--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -62,22 +62,32 @@ changing soon).
 ```{r}
 # Set the number of tokens to pad/truncate the result to.
 n_tokens <- 20L
-n_inputs <- length(text_inputs)
-tokenized <- torchtransformers::tokenize_bert(text_inputs$segment1,
-                                              text_inputs$segment2,
-                                              n_tokens = n_tokens)
+tokenized <- torchtransformers::tokenize_bert(
+  text_inputs$segment1,
+  text_inputs$segment2,
+  n_tokens = n_tokens
+)
 ```
 
 Load a pretrained BERT model and pass in the input:
 
 ```{r}
-bert_model <- torchtransformers::make_and_load_bert(
-  model_name = "bert_base_uncased"
+# If we're downloading this model for the first time, it can take longer than
+# the default timeout.
+# TODO: Build this into torchtransformers and/or dlr.
+old_timeout <- options(timeout = 1000)
+bert_model <- torchtransformers::model_bert_pretrained(
+  bert_type = "bert_base_uncased"
 )
+options(old_timeout)
 
 bert_model$eval() 
-bert_output <- bert_model(torch::torch_tensor(tokenized$token_ids), 
-                          torch::torch_tensor(tokenized$token_type_ids))
+bert_output <- bert_model(
+  list(
+    token_ids = torch::torch_tensor(tokenized$token_ids), 
+    token_type_ids = torch::torch_tensor(tokenized$token_type_ids)
+  )
+)
 ```
 
 ## Extracting embeddings in tidy form
@@ -171,7 +181,7 @@ process_synant <- function(source_file) {
 synant_url <- "https://www.gutenberg.org/files/51155/old/20190304-51155.csv"
 synant_tidy <- dlr::read_or_cache(
   source_path = synant_url,
-  appname = "torchtransformers",
+  appname = "tidybert",
   process_f = process_synant
 )
 
@@ -202,7 +212,7 @@ The minimum number of tokens we will need is five, but some of the words will co
 bert_classifier <- bert_classification(
   x = dplyr::select(training_set, word, other_word),
   y = dplyr::select(training_set, target),
-  model_name = "bert_tiny_uncased",
+  bert_type = "bert_tiny_uncased",
   n_tokens = 14L, # don't need many tokens for this
   epochs = 5L
 )
@@ -213,16 +223,16 @@ Let's see what the predictions are on the test set.
 ```{r, eval = FALSE}
 preds <- predict(bert_classifier, dplyr::select(testing_set, word, other_word))
 mean(preds$.pred_class == testing_set$target)
-# [1] 0.7479572 # YMMV
+# [1] 0.8206537 # YMMV
 
 # We can also try arbitrary input.
 predict(
-      bert_classifier,
-      dplyr::tibble(
-        word = c("spacious", "spacious"),
-        other_word = c("cramped", "roomy")
-      )
-    )
+  bert_classifier,
+  dplyr::tibble(
+    word = c("spacious", "spacious"),
+    other_word = c("cramped", "roomy")
+  )
+)
 # # A tibble: 2 × 1
 #   .pred_class
 #   <fct>      

--- a/vignettes/bert_classification.Rmd
+++ b/vignettes/bert_classification.Rmd
@@ -109,7 +109,7 @@ torch::torch_manual_seed(1234)
 entailment_fit_formula <- bert_classification(
   gold_label ~ sentence1 + sentence2, 
   data = train_head,
-  model_name = "bert_tiny_uncased",
+  bert_type = "bert_tiny_uncased",
   n_tokens = 128,
   epochs = 1
 )
@@ -119,7 +119,7 @@ torch::torch_manual_seed(1234)
 entailment_fit_dataframe <- bert_classification(
   x = dplyr::select(train_head, sentence1, sentence2),
   y = train_head$gold_label,
-  model_name = "bert_tiny_uncased",
+  bert_type = "bert_tiny_uncased",
   n_tokens = 128,
   epochs = 1
 )
@@ -129,7 +129,7 @@ torch::torch_manual_seed(1234)
 entailment_fit_matrix <- bert_classification(
   x = as.matrix(dplyr::select(train_head, sentence1, sentence2)),
   y = train_head$gold_label,
-  model_name = "bert_tiny_uncased",
+  bert_type = "bert_tiny_uncased",
   n_tokens = 128,
   epochs = 1
 )

--- a/vignettes/bert_classification.Rmd
+++ b/vignettes/bert_classification.Rmd
@@ -79,9 +79,6 @@ process_mnli <- function(source_file) {
   return(mnli_tibbles)
 }
 
-# By default downloading large files often fails. Increase the timeout.
-old_timeout <- options(timeout = 1000)
-
 data_url <- "https://dl.fbaipublicfiles.com/glue/data/MNLI.zip"
 
 mnli_tibbles <- dlr::read_or_cache(
@@ -89,9 +86,6 @@ mnli_tibbles <- dlr::read_or_cache(
   appname = "tidybert",
   process_f = process_mnli
 )
-
-# Restore the timeout.
-options(old_timeout)
 ```
 
 ## Fit the Model


### PR DESCRIPTION
`gp` doesn't like some long code lines, but everything else passes. You might need this for `covr` to be fully happy (plus presumably we'll still have Windows-vs-non-Windows issues):

```
Sys.setenv(NOT_CRAN = 'true')
goodpractice::gp()
Sys.setenv(NOT_CRAN = "")
```