### PR TITLE
transition `parsnip::set_model_args()` inputs to main arguments

### DIFF
--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -202,13 +202,16 @@
 #'   number of epochs for training.
 #' @param batch_size The number of samples to load in each batch during
 #'   training.
+#' @inheritParams bert_classification
 #'
 #' @return A specification for a model.
 #' @export
 bert <- function(mode = "unknown",
                  engine = "tidybert",
                  epochs = 10,
-                 batch_size = 128) {
+                 batch_size = 128,
+                 bert_type = "bert_small_uncased",
+                 n_tokens = 1) {
   # This only makes sense if they have parsnip installed.
   rlang::check_installed("parsnip")
 
@@ -218,7 +221,9 @@ bert <- function(mode = "unknown",
   # Capture the arguments in quosures
   args <- list(
     epochs = rlang::enquo(epochs),
-    batch_size = rlang::enquo(batch_size)
+    batch_size = rlang::enquo(batch_size),
+    bert_type = rlang::enquo(bert_type),
+    n_tokens = rlang::enquo(n_tokens)
   )
 
   # Save some empty slots for future parts of the specification

--- a/man/bert.Rd
+++ b/man/bert.Rd
@@ -4,7 +4,14 @@
 \alias{bert}
 \title{Fine-Tune a BERT Model}
 \usage{
-bert(mode = "unknown", engine = "tidybert", epochs = 10, batch_size = 128)
+bert(
+  mode = "unknown",
+  engine = "tidybert",
+  epochs = 10,
+  batch_size = 128,
+  bert_type = "bert_small_uncased",
+  n_tokens = 1
+)
 }
 \arguments{
 \item{mode}{A single character string for the prediction outcome mode.
@@ -20,6 +27,12 @@ number of epochs for training.}
 
 \item{batch_size}{The number of samples to load in each batch during
 training.}
+
+\item{bert_type}{Character; which flavor of BERT to use. See
+\code{\link[torchtransformers:available_berts]{available_berts()}} for known models.}
+
+\item{n_tokens}{An integer scalar indicating the number of tokens in the
+output.}
 }
 \value{
 A specification for a model.


### PR DESCRIPTION
Hey there! Super stoked yall are putting this together.

Similar reprex to tidymodels/parsnip#832, with this PR:

``` r
library(tidybert)
library(tidymodels)
library(modeldata)
tidymodels_prefer()

data(tate_text)
tate_text <- tate_text %>%
  # We'll just work with the top 6 artists.
  dplyr::filter(
    artist %in% c(
      "Schütte, Thomas", "Zaatari, Akram", "Beuys, Joseph", "Ferrari, León",
      "Kossoff, Leon", "Tillmans, Wolfgang"
    )
  ) %>%
  dplyr::mutate(
    artist = as.factor(as.character(artist))
  )
set.seed(4242)
tate_folds <- rsample::vfold_cv(tate_text, v = 3)

tidybert_spec <-
  bert(
    mode = "classification",
    epochs = 1,
    bert_type = tune(),
    n_tokens = tune()
  ) %>%
  parsnip::set_engine(
    "tidybert"
  )

tidybert_workflow <- workflows::workflow(
  artist ~ title,
  tidybert_spec
)

grid <- tidybert_workflow %>%
  workflows::extract_parameter_set_dials() %>%
  update(
    bert_type = bert_type(
      c("bert_small_uncased", "bert_tiny_uncased")
    ),
    n_tokens = n_tokens(c(4, 5))
  ) %>%
  dials::grid_latin_hypercube(size = 2)

torch::torch_manual_seed(4242)
tidybert_result <- tidybert_workflow %>%
  tune::tune_grid(
    resamples = tate_folds,
    grid = grid
  )

tidybert_result
#> # Tuning results
#> # 3-fold cross-validation 
#> # A tibble: 3 × 4
#>   splits            id    .metrics         .notes          
#>   <list>            <chr> <list>           <list>          
#> 1 <split [405/203]> Fold1 <tibble [4 × 6]> <tibble [0 × 3]>
#> 2 <split [405/203]> Fold2 <tibble [4 × 6]> <tibble [0 × 3]>
#> 3 <split [406/202]> Fold3 <tibble [4 × 6]> <tibble [0 × 3]>
```

<sup>Created on 2022-10-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Some more details on this suggestion [here](https://github.com/tidymodels/parsnip/issues/832#issuecomment-1295406770). :)